### PR TITLE
Fix icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<!--<link rel="icon" type="image/svg+xml" href="/" />-->
+		<link rel="icon" type="image/svg+xml" href="https://brand.gatech.edu/themes/custom/brand/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Scientific Software Engineering Center</title>
 	</head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "csse-showcase",
       "version": "0.0.0",
       "dependencies": {
+        "@icons-pack/react-simple-icons": "^13.7.0",
         "@tailwindcss/postcss": "^4.1.13",
         "@tailwindcss/vite": "^4.1.13",
         "class-variance-authority": "^0.7.1",
@@ -991,6 +992,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@icons-pack/react-simple-icons": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-13.7.0.tgz",
+      "integrity": "sha512-Vx5mnIm/3gD/9dpCfw/EdCXwzCswmvWnvMjL6zUJTbpk2PuyCdx5zSfiX8KQKYszD/1Z2mfaiBtqCxlHuDcpuA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@isaacs/fs-minipass": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@icons-pack/react-simple-icons": "^13.7.0",
     "@tailwindcss/postcss": "^4.1.13",
     "@tailwindcss/vite": "^4.1.13",
     "class-variance-authority": "^0.7.1",

--- a/src/pages/project-detail.tsx
+++ b/src/pages/project-detail.tsx
@@ -1,8 +1,6 @@
 import { useParams, useLocation } from "wouter";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-  Github,
   ExternalLink,
   ArrowLeft,
   Calendar,
@@ -10,6 +8,7 @@ import {
   Building,
   Target,
 } from "lucide-react";
+import { SiGithub } from '@icons-pack/react-simple-icons';
 import PageHeader from "@/components/ui/page-header";
 import ProjectOnePager from "@/components/projects/project-one-pager";
 import { projects } from "@/data/projects";
@@ -353,7 +352,7 @@ export default function ProjectDetail() {
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        <Github className="mr-2 h-4 w-4" /> 
+                        <SiGithub className="mr-2 h-4 w-4" /> 
                         {Array.isArray(project.githubUrl) && project.githubUrl.length > 1 ? `GitHub ${index + 1}` : 'View on GitHub'}
                       </a>
                     </Button>


### PR DESCRIPTION
Make sure to load the correct GT favicon and upgrade the Github icon tag since `<Github>` was deprecated.