### PR TITLE
Compile to build directory so we can deploy via actions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## :pencil: Description
+
+Please include a summary of the change.
+
+## :gear: Work Item
+
+Please include link to the corresponding GitHub Issue or Project work item.
+
+## :movie_camera: Demo
+
+Please provide any images, GIFs, or videos that show the effect of your changes (if applicable). A picture is worth a thousand words.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,7 +17,7 @@ const compat = new FlatCompat({
 });
 
 export default defineConfig([
-    globalIgnores(["dist",]),
+    globalIgnores(["build",]),
     {
         files: ['**/*.{ts,tsx}'],
         extends: compat.extends("eslint:recommended", "plugin:react/recommended"),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d build"
   },
   "dependencies": {
     "@icons-pack/react-simple-icons": "^13.7.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,6 @@ export default defineConfig({
   },
   root: path.resolve(__dirname, "."),
   build: {
-    outDir: path.resolve(__dirname, "dist/"),
+    outDir: path.resolve(__dirname, "build/"),
   },
 })


### PR DESCRIPTION
## :pencil: Description

Change the output directory from `dist` to `build` so we can deploy via the GitHub action.

I am also piggybacking the pull request template on this PR since @rfievet and I discussed it a few minutes ago.

## :gear: Work Item

N/A
