### PR TITLE
Add DropdownMenu component in favor of Popover

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,7 +6,7 @@
   "bracketSameLine": true,
   "bracketSpacing": true,
   "singleQuote": false,
-  "trailingComma": "none",
+  "trailingComma": "es5",
   "semi": true,
   "printWidth": 100,
   "ignore": [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,5 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import react from "eslint-plugin-react";
-import stylisticJs from "@stylistic/eslint-plugin";
 import globals from "globals";
 import tsParser from "@typescript-eslint/parser";
 import path from "node:path";
@@ -23,8 +22,7 @@ export default defineConfig([
         extends: compat.extends("eslint:recommended", "plugin:react/recommended"),
 
         plugins: {
-            react,
-            "@stylistic": stylisticJs,
+            react
         },
 
         languageOptions: {
@@ -55,7 +53,6 @@ export default defineConfig([
                 afterColon: true,
             }],
 
-            "@stylistic/indent": ["error", 2],
             "react/react-in-jsx-scope": "off",
         },
     }]);

--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
     <link rel="icon" type="image/svg+xml" href="https://brand.gatech.edu/themes/custom/brand/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Center for Scientific Software Engineering</title>
+
+    <!-- FontAwesome Kit. This is currently using Varun Agrawal's account. -->
+    <script src="https://kit.fontawesome.com/7dd0cc8243.js" crossorigin="anonymous"></script>
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -6,9 +6,6 @@
     <link rel="icon" type="image/svg+xml" href="https://brand.gatech.edu/themes/custom/brand/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Center for Scientific Software Engineering</title>
-
-    <!-- FontAwesome Kit. This is currently using Varun Agrawal's account. -->
-    <script src="https://kit.fontawesome.com/7dd0cc8243.js" crossorigin="anonymous"></script>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@icons-pack/react-simple-icons": "^13.7.0",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@tailwindcss/postcss": "^4.1.13",
         "@tailwindcss/vite": "^4.1.13",
         "class-variance-authority": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "csse-showcase",
       "version": "1.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^7.1.0",
+        "@fortawesome/free-brands-svg-icons": "^7.1.0",
+        "@fortawesome/free-regular-svg-icons": "^7.1.0",
+        "@fortawesome/free-solid-svg-icons": "^7.1.0",
+        "@fortawesome/react-fontawesome": "^3.1.0",
         "@icons-pack/react-simple-icons": "^13.7.0",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@tailwindcss/postcss": "^4.1.13",
@@ -89,7 +94,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -948,6 +952,76 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz",
+      "integrity": "sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz",
+      "integrity": "sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.1.0.tgz",
+      "integrity": "sha512-9byUd9bgNfthsZAjBl6GxOu1VPHgBuRUP9juI7ZoM98h8xNPTCTagfwUFyYscdZq4Hr7gD1azMfM9s5tIWKZZA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.1.0.tgz",
+      "integrity": "sha512-0e2fdEyB4AR+e6kU4yxwA/MonnYcw/CsMEP9lH82ORFi9svA6/RhDyhxIv5mlJaldmaHLLYVTb+3iEr+PDSZuQ==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.1.0.tgz",
+      "integrity": "sha512-Udu3K7SzAo9N013qt7qmm22/wo2hADdheXtBfxFTecp+ogsc0caQNRKEb7pkvvagUGOpG9wJC1ViH6WXs8oXIA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.1.0.tgz",
+      "integrity": "sha512-5OUQH9aDH/xHJwnpD4J7oEdGvFGJgYnGe0UebaPIdMW9UxYC/f5jv2VjVEgnikdJN0HL8yQxp9Nq+7gqGZpIIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
+        "react": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -3275,7 +3349,6 @@
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.12.0"
       }
@@ -3286,7 +3359,6 @@
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3297,7 +3369,6 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3358,7 +3429,6 @@
       "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.1",
         "@typescript-eslint/types": "8.44.1",
@@ -3611,7 +3681,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3923,7 +3992,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -4695,7 +4763,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7014,7 +7081,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7024,7 +7090,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -7716,8 +7781,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -7805,7 +7869,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7965,7 +8028,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8139,7 +8201,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.7.tgz",
       "integrity": "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -8231,7 +8292,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@eslint/eslintrc": "^3.3.1",
         "@eslint/js": "^9.36.0",
         "@nabla/vite-plugin-eslint": "^2.0.6",
-        "@stylistic/eslint-plugin": "^5.4.0",
         "@tailwindcss/typography": "^0.5.18",
         "@types/node": "^24.5.2",
         "@types/react": "^19.1.13",
@@ -2912,40 +2911,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.4.0.tgz",
-      "integrity": "sha512-UG8hdElzuBDzIbjG1QDwnYH0MQ73YLXDFHgZzB4Zh/YJfnw8XNsloVtytqzx0I2Qky9THSdpTmi8Vjn/pf/Lew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.0",
-        "@typescript-eslint/types": "^8.44.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "estraverse": "^5.3.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=9.0.0"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.13",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@icons-pack/react-simple-icons": "^13.7.0",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@tailwindcss/postcss": "^4.1.13",
     "@tailwindcss/vite": "^4.1.13",
     "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.36.0",
     "@nabla/vite-plugin-eslint": "^2.0.6",
-    "@stylistic/eslint-plugin": "^5.4.0",
     "@tailwindcss/typography": "^0.5.18",
     "@types/node": "^24.5.2",
     "@types/react": "^19.1.13",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "deploy": "gh-pages -d build"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^7.1.0",
+    "@fortawesome/free-brands-svg-icons": "^7.1.0",
+    "@fortawesome/free-regular-svg-icons": "^7.1.0",
+    "@fortawesome/free-solid-svg-icons": "^7.1.0",
+    "@fortawesome/react-fontawesome": "^3.1.0",
     "@icons-pack/react-simple-icons": "^13.7.0",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@tailwindcss/postcss": "^4.1.13",

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,3 +1,7 @@
+import { type IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+/* import all the icons in Free Solid, Free Regular, and Brands styles */
+import { faGithub, faLinkedin, faXTwitter, faYoutube } from "@fortawesome/free-brands-svg-icons";
 import React from "react";
 import { Link } from "wouter";
 import imgGtLogoWhite from "/images/gt-logo-white.svg";
@@ -24,22 +28,13 @@ export default function Footer() {
               , advances research through professional software engineering practices.
             </p>
             <div className="flex space-x-4">
-              <SocialLink
-                href="https://twitter.com/georgiatech"
-                icon="fa-brands fa-x-twitter fa-lg"
-              />
+              <SocialLink href="https://twitter.com/georgiatech" icon={faXTwitter} />
               <SocialLink
                 href="https://linkedin.com/school/georgia-institute-of-technology/"
-                icon="fa-brands fa-linkedin-in fa-lg"
+                icon={faLinkedin}
               />
-              <SocialLink
-                href="https://github.com/gt-sse-center"
-                icon="fa-brands fa-github fa-lg"
-              />
-              <SocialLink
-                href="https://www.youtube.com/user/GeorgiaTech"
-                icon="fa-brands fa-youtube fa-lg"
-              />
+              <SocialLink href="https://github.com/gt-sse-center" icon={faGithub} />
+              <SocialLink href="https://www.youtube.com/user/GeorgiaTech" icon={faYoutube} />
             </div>
           </div>
 
@@ -153,7 +148,7 @@ function ExternalFooterLink({ href, children }: FooterLinkProps) {
       href: href,
       target: "_blank",
       rel: "noopener noreferrer",
-      children: children
+      children: children,
     },
     true
   );
@@ -161,7 +156,7 @@ function ExternalFooterLink({ href, children }: FooterLinkProps) {
 
 interface SocialLinkProps {
   href: string;
-  icon: string;
+  icon: IconDefinition;
 }
 
 function SocialLink({ href, icon }: SocialLinkProps) {
@@ -171,7 +166,7 @@ function SocialLink({ href, icon }: SocialLinkProps) {
       target="_blank"
       rel="noopener noreferrer"
       className="text-gray-300 hover:text-white transition duration-150 ease-in-out">
-      <i className={icon}></i>
+      <FontAwesomeIcon icon={icon} size="xl" />
     </a>
   );
 }

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -24,13 +24,22 @@ export default function Footer() {
               , advances research through professional software engineering practices.
             </p>
             <div className="flex space-x-4">
-              <SocialLink href="https://twitter.com/georgiatech" icon="fab fa-twitter" />
+              <SocialLink
+                href="https://twitter.com/georgiatech"
+                icon="fa-brands fa-x-twitter fa-lg"
+              />
               <SocialLink
                 href="https://linkedin.com/school/georgia-institute-of-technology/"
-                icon="fab fa-linkedin-in"
+                icon="fa-brands fa-linkedin-in fa-lg"
               />
-              <SocialLink href="https://github.com/gt-sse-center" icon="fab fa-github" />
-              <SocialLink href="https://www.youtube.com/user/GeorgiaTech" icon="fab fa-youtube" />
+              <SocialLink
+                href="https://github.com/gt-sse-center"
+                icon="fa-brands fa-github fa-lg"
+              />
+              <SocialLink
+                href="https://www.youtube.com/user/GeorgiaTech"
+                icon="fa-brands fa-youtube fa-lg"
+              />
             </div>
           </div>
 
@@ -39,45 +48,35 @@ export default function Footer() {
             <ul className="space-y-2">
               <FooterLink href="/">Home</FooterLink>
               <FooterLink href="/projects">Projects</FooterLink>
-              <li>
-                <a
-                  href={`${import.meta.env.VITE_CSSE_GT_PAGE}/people/`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-gray-300 hover:text-white transition duration-150 ease-in-out">
-                  Team
-                </a>
-              </li>
-              <li>
-                <a
-                  href={`${import.meta.env.VITE_CSSE_GT_PAGE}/events/`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-gray-300 hover:text-white transition duration-150 ease-in-out">
-                  Events
-                </a>
-              </li>
-              <li>
-                <a
-                  href={`${import.meta.env.VITE_CSSE_GT_PAGE}/contact/`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-gray-300 hover:text-white transition duration-150 ease-in-out">
-                  Contact
-                </a>
-              </li>
+              <ExternalFooterLink href={`${import.meta.env.VITE_CSSE_GT_PAGE}/people/`}>
+                Team
+              </ExternalFooterLink>
+              <ExternalFooterLink href={`${import.meta.env.VITE_CSSE_GT_PAGE}/events/`}>
+                Events
+              </ExternalFooterLink>
+              <ExternalFooterLink href={`${import.meta.env.VITE_CSSE_GT_PAGE}/contact/`}>
+                Contact
+              </ExternalFooterLink>
             </ul>
           </div>
 
           <div>
             <h3 className="font-bold text-xl mb-4">Georgia Tech</h3>
             <ul className="space-y-2">
-              <ExternalLink href="https://www.gatech.edu">Main Website</ExternalLink>
-              <ExternalLink href="https://www.cc.gatech.edu">College of Computing</ExternalLink>
-              <ExternalLink href="https://www.cos.gatech.edu">College of Sciences</ExternalLink>
-              <ExternalLink href="https://www.coe.gatech.edu">College of Engineering</ExternalLink>
-              <ExternalLink href="https://www.research.gatech.edu">Research Portal</ExternalLink>
-              <ExternalLink href="https://www.library.gatech.edu">Library</ExternalLink>
+              <ExternalFooterLink href="https://www.gatech.edu">Main Website</ExternalFooterLink>
+              <ExternalFooterLink href="https://www.cc.gatech.edu">
+                College of Computing
+              </ExternalFooterLink>
+              <ExternalFooterLink href="https://www.cos.gatech.edu">
+                College of Sciences
+              </ExternalFooterLink>
+              <ExternalFooterLink href="https://www.coe.gatech.edu">
+                College of Engineering
+              </ExternalFooterLink>
+              <ExternalFooterLink href="https://www.research.gatech.edu">
+                Research Portal
+              </ExternalFooterLink>
+              <ExternalFooterLink href="https://www.library.gatech.edu">Library</ExternalFooterLink>
             </ul>
           </div>
         </div>
@@ -116,38 +115,47 @@ export default function Footer() {
 
 interface FooterLinkProps {
   href: string;
+  rel?: string;
+  target?: string;
   children: React.ReactNode;
 }
 
-function FooterLink({ href, children }: FooterLinkProps) {
+function FooterLink(
+  { href, target = "", rel = "", children }: FooterLinkProps,
+  isExternal: boolean = false
+) {
   return (
     <li>
-      <Link
-        href={href}
-        className="text-gray-300 hover:text-white transition duration-150 ease-in-out">
-        {children}
-      </Link>
+      {isExternal ? (
+        <a
+          href={href}
+          target={target}
+          rel={rel}
+          className="text-gray-300 hover:text-white transition duration-150 ease-in-out">
+          {children}
+        </a>
+      ) : (
+        <Link
+          href={href}
+          target={target}
+          rel={rel}
+          className="text-gray-300 hover:text-white transition duration-150 ease-in-out">
+          {children}
+        </Link>
+      )}
     </li>
   );
 }
 
-interface ExternalLinkProps {
-  href: string;
-  children: React.ReactNode;
-}
-
-//TODO(Varun): Rename to ListExternalLink
-function ExternalLink({ href, children }: ExternalLinkProps) {
-  return (
-    <li>
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-gray-300 hover:text-white transition duration-150 ease-in-out">
-        {children}
-      </a>
-    </li>
+function ExternalFooterLink({ href, children }: FooterLinkProps) {
+  return FooterLink(
+    {
+      href: href,
+      target: "_blank",
+      rel: "noopener noreferrer",
+      children: children
+    },
+    true
   );
 }
 

--- a/src/components/projects/filter-button.tsx
+++ b/src/components/projects/filter-button.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@/components/ui/button";
+
+interface FilterButtonProps {
+  filter: string;
+  activeFilter: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+/**
+ * A button which accepts an `onClick` function to
+ * filterout content based on the button's value.
+ */
+function FilterButton({ filter, activeFilter, onClick, children }: FilterButtonProps) {
+  const isActive = filter === activeFilter;
+
+  return (
+    <Button
+      variant={isActive ? "default" : "outline"}
+      className={`rounded-full ${
+        isActive
+          ? "bg-[var(--gt-gold)] text-white hover:bg-[var(--gt-tech-light-gold)] hover:text-[var(--gt-info)]"
+          : "border-[var(--gt-gold)] text-[var(--gt-info)] hover:bg-[var(--gt-gold)] hover:text-white"
+      }`}
+      onClick={onClick}>
+      {children}
+    </Button>
+  );
+}
+
+export { FilterButton };

--- a/src/components/projects/filter-button.tsx
+++ b/src/components/projects/filter-button.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import React from "react";
 
 interface FilterButtonProps {
   filter: string;

--- a/src/components/projects/project-filters.tsx
+++ b/src/components/projects/project-filters.tsx
@@ -1,9 +1,10 @@
 /*eslint no-unused-vars: "off"*/
 
+import { FilterButton } from "@/components/projects/filter-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown";
 import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   getAllCategoriesFromProjects,
   getAllTechnologiesFromProjects,
@@ -11,7 +12,7 @@ import {
 } from "@/lib/utils";
 import { type Project } from "@/schema";
 import { ArrowUpDown, Check, Filter, Search, X } from "lucide-react";
-import React, { useState } from "react";
+import { useState } from "react";
 
 interface ProjectFiltersProps {
   activeFilter: string;
@@ -106,7 +107,7 @@ export default function ProjectFilters({
         ))}
       </div>
 
-      {/* Search and Filter Row */}
+      {/* Search, Sort, and Filter Row */}
       <div className="flex flex-col sm:flex-row gap-4 items-center justify-center mb-6">
         {/* Search Input */}
         <div className="relative w-full max-w-md">
@@ -124,8 +125,8 @@ export default function ProjectFilters({
         </div>
 
         {/* Sort Dropdown */}
-        <Popover open={sortFilterOpen} onOpenChange={setSortFilterOpen}>
-          <PopoverTrigger asChild>
+        <DropdownMenu open={sortFilterOpen} onOpenChange={setSortFilterOpen}>
+          <DropdownMenuTrigger asChild>
             <Button variant="outline" className="w-full sm:w-auto min-w-[160px] justify-between">
               <div className="flex items-center gap-2">
                 <ArrowUpDown className="h-4 w-4" />
@@ -142,8 +143,8 @@ export default function ProjectFilters({
                 </span>
               </div>
             </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[180px] p-2" align="start">
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-[180px] p-2" align="start">
             <div className="space-y-1">
               {[
                 { value: "newest", label: "Newest First" },
@@ -167,12 +168,12 @@ export default function ProjectFilters({
                 </div>
               ))}
             </div>
-          </PopoverContent>
-        </Popover>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
         {/* Technology Filter Dropdown */}
-        <Popover open={techFilterOpen} onOpenChange={setTechFilterOpen}>
-          <PopoverTrigger asChild>
+        <DropdownMenu open={techFilterOpen} onOpenChange={setTechFilterOpen}>
+          <DropdownMenuTrigger asChild>
             <Button variant="outline" className="w-full sm:w-auto min-w-[200px] justify-between">
               <div className="flex items-center gap-2">
                 <Filter className="h-4 w-4" />
@@ -183,8 +184,8 @@ export default function ProjectFilters({
                 </span>
               </div>
             </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-[400px] p-4" align="start">
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="w-[400px] p-4" align="start">
             <div className="max-h-[300px] overflow-y-auto">
               <div className="mb-3">
                 <Input placeholder="Search technologies..." className="w-full" />
@@ -218,11 +219,11 @@ export default function ProjectFilters({
                 </div>
               ))}
             </div>
-          </PopoverContent>
-        </Popover>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
-      {/* Selected Technology Tags */}
+      {/* Selected Technology Pills */}
       {selectedTechnologies.length > 0 && (
         <div className="flex flex-wrap gap-2 justify-center mb-4">
           {selectedTechnologies.map((tech) => (
@@ -245,29 +246,5 @@ export default function ProjectFilters({
         </div>
       )}
     </div>
-  );
-}
-
-interface FilterButtonProps {
-  filter: string;
-  activeFilter: string;
-  onClick: () => void;
-  children: React.ReactNode;
-}
-
-function FilterButton({ filter, activeFilter, onClick, children }: FilterButtonProps) {
-  const isActive = filter === activeFilter;
-
-  return (
-    <Button
-      variant={isActive ? "default" : "outline"}
-      className={`rounded-full ${
-        isActive
-          ? "bg-[var(--gt-gold)] text-white hover:bg-[var(--gt-tech-light-gold)] hover:text-[var(--gt-info)]"
-          : "border-[var(--gt-gold)] text-[var(--gt-info)] hover:bg-[var(--gt-gold)] hover:text-white"
-      }`}
-      onClick={onClick}>
-      {children}
-    </Button>
   );
 }

--- a/src/components/ui/dropdown.tsx
+++ b/src/components/ui/dropdown.tsx
@@ -1,0 +1,36 @@
+import { cn } from '@/lib/utils';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import React from 'react';
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+/**
+ * Component to add the content within a dropdown menu.
+ * Wraps radix-ui's DropdownMenu Portal and Content into one.
+ */
+function DropdownMenuContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ref,
+  ...props
+}: React.ComponentPropsWithRef<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-72 rounded-md border bg-dropdownmenu p-4 text-dropdownmenu-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+export { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,7 +1,6 @@
+import { cn } from "@/lib/utils";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import * as React from "react";
-
-import { cn } from "@/lib/utils";
 
 const Popover = PopoverPrimitive.Root;
 

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -7,79 +7,82 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme {
-	--variant: professional;
-	--primary: hsl(217, 100%, 17%);
-	--appearance: light;
-	--radius: 0.5;
+  --variant: professional;
+  --primary: hsl(217, 100%, 17%);
+  --appearance: light;
+  --radius: 0.5;
 
-	--radius-lg: var(--radius);
-	--radius-md: calc(var(--radius) - 2px);
-	--radius-sm: calc(var(--radius) - 4px);
+  --radius-lg: var(--radius);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) - 4px);
 
-	/* TODO(Varun) A lot of these variables are undefined. Fix them!! */
+  /* TODO(Varun) A lot of these variables are undefined. Fix them!! */
 
-	--color-background: var(--background);
-	--color-foreground: var(--foreground);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
 
-	--color-card: hsl(var(--card));
-	--color-card-foreground: hsl(var(--card-foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
 
-	--color-popover: var(--gt-white);
-	--color-popover-foreground: var(--gt-navy);
+  --color-popover: var(--gt-white);
+  --color-popover-foreground: var(--gt-navy);
 
-	--color-primary: hsl(var(--primary));
-	--color-primary-foreground: hsl(var(--primary-foreground));
+  --color-dropdownmenu: var(--gt-white);
+  --color-dropdownmenu-foreground: var(--gt-navy);
 
-	--color-secondary: hsl(var(--secondary));
-	--color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
 
-	--color-muted: hsl(var(--muted));
-	--color-muted-foreground: hsl(var(--muted-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
 
-	--color-accent: hsl(var(--accent));
-	--color-accent-foreground: hsl(var(--accent-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
 
-	--color-destructive: hsl(var(--destructive));
-	--color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
 
-	--color-border: hsl(var(--border));
-	--color-input: hsl(var(--input));
-	--color-ring: hsl(var(--ring));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
 
-	--color-chart-1: hsl(var(--chart-1));
-	--color-chart-2: hsl(var(--chart-2));
-	--color-chart-3: hsl(var(--chart-3));
-	--color-chart-4: hsl(var(--chart-4));
-	--color-chart-5: hsl(var(--chart-5));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
 
-	--color-sidebar: hsl(var(--sidebar-background));
-	--color-sidebar-foreground: hsl(var(--sidebar-foreground));
-	--color-sidebar-primary: hsl(var(--sidebar-primary));
-	--color-sidebar-primary-foreground: hsl(var(--sidebar-primary-foreground));
-	--color-sidebar-accent: hsl(var(--sidebar-accent));
-	--color-sidebar-accent-foreground: hsl(var(--sidebar-accent-foreground));
-	--color-sidebar-border: hsl(var(--sidebar-border));
-	--color-sidebar-ring: hsl(var(--sidebar-ring));
+  --color-chart-1: hsl(var(--chart-1));
+  --color-chart-2: hsl(var(--chart-2));
+  --color-chart-3: hsl(var(--chart-3));
+  --color-chart-4: hsl(var(--chart-4));
+  --color-chart-5: hsl(var(--chart-5));
 
-	--animate-accordion-down: accordion-down 0.2s ease-out;
-	--animate-accordion-up: accordion-up 0.2s ease-out;
+  --color-sidebar: hsl(var(--sidebar-background));
+  --color-sidebar-foreground: hsl(var(--sidebar-foreground));
+  --color-sidebar-primary: hsl(var(--sidebar-primary));
+  --color-sidebar-primary-foreground: hsl(var(--sidebar-primary-foreground));
+  --color-sidebar-accent: hsl(var(--sidebar-accent));
+  --color-sidebar-accent-foreground: hsl(var(--sidebar-accent-foreground));
+  --color-sidebar-border: hsl(var(--sidebar-border));
+  --color-sidebar-ring: hsl(var(--sidebar-ring));
 
-	@keyframes accordion-down {
-		from {
-			height: 0;
-		}
-		to {
-			height: var(--radix-accordion-content-height);
-		}
-	}
-	@keyframes accordion-up {
-		from {
-			height: var(--radix-accordion-content-height);
-		}
-		to {
-			height: 0;
-		}
-	}
+  --animate-accordion-down: accordion-down 0.2s ease-out;
+  --animate-accordion-up: accordion-up 0.2s ease-out;
+
+  @keyframes accordion-down {
+    from {
+      height: 0;
+    }
+    to {
+      height: var(--radix-accordion-content-height);
+    }
+  }
+  @keyframes accordion-up {
+    from {
+      height: var(--radix-accordion-content-height);
+    }
+    to {
+      height: 0;
+    }
+  }
 }
 
 /*
@@ -91,46 +94,46 @@
   color utility to any element that depends on these defaults.
 */
 @layer base {
-	*,
-	::after,
-	::before,
-	::backdrop,
-	::file-selector-button {
-		border-color: var(--color-gray-200, currentcolor);
-	}
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentcolor);
+  }
 }
 
 @utility bg-pattern {
-	background-color: #003057;
-	background-image: linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
-		linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-	background-size: 50px 50px;
-	background-position: -1px -1px;
+  background-color: #003057;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 50px 50px;
+  background-position: -1px -1px;
 }
 
 @utility animate-fade-in {
-	animation: fadeIn 0.8s ease-in-out;
+  animation: fadeIn 0.8s ease-in-out;
 }
 
 @layer base {
-	* {
-		@apply border-border;
-	}
+  * {
+    @apply border-border;
+  }
 
-	body {
-		@apply font-sans antialiased bg-background text-foreground;
-	}
+  body {
+    @apply font-sans antialiased bg-background text-foreground;
+  }
 }
 
 @layer utilities {
-	@keyframes fadeIn {
-		from {
-			opacity: 0;
-			transform: translateY(10px);
-		}
-		to {
-			opacity: 1;
-			transform: translateY(0);
-		}
-	}
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 }


### PR DESCRIPTION
## :pencil: Description

Use the `DropdownMenu` component instead of the `Popover` in selecting sorting and filtering settings. This makes for better semantics and behavior going forward since popovers are meant more for static display than interactivity.

This also includes the changes from #62.
